### PR TITLE
Fix hibernate data truncation for status

### DIFF
--- a/backend/gorentals/src/main/java/com/example/gorentals/entity/Booking.java
+++ b/backend/gorentals/src/main/java/com/example/gorentals/entity/Booking.java
@@ -35,7 +35,7 @@ public class Booking {
     private LocalDate endDate;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 32)
     private RentalStatus status;
 
     @Column(nullable = false)


### PR DESCRIPTION
Increase the column length for `Booking.status` to resolve data truncation errors when persisting longer `RentalStatus` enum values.

---
<a href="https://cursor.com/background-agent?bcId=bc-e037d4d2-8468-4c6a-afff-4dc700ade5e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e037d4d2-8468-4c6a-afff-4dc700ade5e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

