### PR TITLE
Fix frontend login redirect after token generation

### DIFF
--- a/frontend/gorentals-frontend/src/pages/auth/Login.jsx
+++ b/frontend/gorentals-frontend/src/pages/auth/Login.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import KlookHeader from '../../components/KlookHeader';
@@ -6,19 +6,22 @@ import KlookFooter from '../../components/KlookFooter';
 import '../../styles/klook.css';
 
 export default function Login() {
-  const { login, loading, error, isAdmin, isUser } = useAuth();
+  const { login, loading, error, isAdmin, isUser, user } = useAuth();
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const res = await login(email, password);
-    if (res.ok) {
+    await login(email, password);
+  };
+
+  useEffect(() => {
+    if (!loading && user) {
       if (isAdmin) navigate('/admin');
       else navigate('/');
     }
-  };
+  }, [user, isAdmin, loading, navigate]);
 
   return (
     <div className="klook">


### PR DESCRIPTION
Refactor login redirect to use `useEffect` for navigation after user state updates.

This fixes an issue where the frontend was not redirecting to the correct dashboard after login due to `isAdmin` being checked before the user's role was fully updated in the auth context.

---
<a href="https://cursor.com/background-agent?bcId=bc-751e1ac1-56c9-4775-9751-65319f9f0ae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-751e1ac1-56c9-4775-9751-65319f9f0ae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

